### PR TITLE
Install scipy/numpy requirements before pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
   - "3.5-dev"
 
 # command to install dependencies
+before_install:
+  - sudo apt-get install -qq python-numpy python-scipy
+  
 install:
   - pip install -e .
   - pip install -r requirements.txt


### PR DESCRIPTION
Fixes following errors:
```
numpy.distutils.system_info.NotFoundError: no lapack/blas resources found
The command "pip install -r requirements.txt" failed and exited with 1 during .
```
