### PR TITLE
Clean requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-numpy>=1.12.0
-pytest-cov>=2.3.1
-pytest>=3.0.3
+numpy>=1.11.0
 scipy>=0.18.1


### PR DESCRIPTION
- Numpy 1.12 isn't ready for Windows yet (https://github.com/conda-forge/conda-forge.github.io/issues/313)
- Don't need testing requirements