### PR TITLE
Removed Python27 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-  - python: 2.7
   - python: 3.2
   - python: 3.3
   - python: 3.4
@@ -18,7 +17,6 @@ matrix:
   - python: 3.7-dev
   - python: nightly
   allow_failures:
-  - python: 2.7
   - python: 3.2
   - python: 3.3
   - python: 3.7-dev


### PR DESCRIPTION
## Proposed Changes
- Speed up build
- Removed Python27 from CI as it's no longer supported for package
