### PR TITLE
Dropping Python 3.2 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-  - python: 3.2
   - python: 3.3
   - python: 3.4
   - python: 3.5
@@ -17,7 +16,6 @@ matrix:
   - python: 3.7-dev
   - python: nightly
   allow_failures:
-  - python: 3.2
   - python: 3.3
   - python: 3.7-dev
   - python: nightly


### PR DESCRIPTION
## Affected Issues
- Related #34 

## Proposed Changes
- Drop Python 3.2 testing
- `typed_ast` package (`mypy` dependency) dropped support for Python <3.2
- Docker test below

```
Status: Downloaded newer image for python:3.2
root@741fd8fd2e24:/# pip -V
pip 7.1.2 from /usr/local/lib/python3.2/site-packages (python 3.2)
root@741fd8fd2e24:/# pip install mypy
Collecting mypy
  Downloading mypy-0.520-py3-none-any.whl (1.1MB)
    100% |████████████████████████████████| 1.1MB 265kB/s
Collecting typed-ast<1.1.0,>=1.0.4 (from mypy)
  Downloading typed-ast-1.0.4.tar.gz (200kB)
    100% |████████████████████████████████| 200kB 1.2MB/s
/usr/local/lib/python3.2/site-packages/pkg_resources/__init__.py:87: UserWarning: Support for Python 3.0-3.2 has been dropped. Future versions will fail here.
  warnings.warn(msg)
    Complete output from command python setup.py egg_info:
    /usr/local/lib/python3.2/site-packages/pkg_resources/__init__.py:87: UserWarning: Support for Python 3.0-3.2 has been dropped. Future versions will fail here.
      warnings.warn(msg)
    Error: typed_ast only runs on Python 3.3 and above.
```
