### PR TITLE
Using pip to manage runtime dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ matrix:
 addons:
   apt:
     packages:
-    - python-numpy
-    - python3-numpy
-    - python-scipy
-    - python3-scipy
     - python-wheel
     - python-wheel-common
     - python3-wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
 addons:
   apt:
     packages:
+    - libopenblas-dev
+    - liblapack-dev
+    - gfortran
     - python-wheel
     - python-wheel-common
     - python3-wheel

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -15,6 +15,7 @@ pytest-cov>=2.5.1
 GitPython>=2.1.5
 pandocfilters>=1.4.1
 pytest>=3.1.3
+setuptools>=36.2.0
 
 # examples
 pandas>=0.20.3

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -14,6 +14,7 @@ pytest-cov>=2.5.1
 # misc
 GitPython>=2.1.5
 pandocfilters>=1.4.1
+pytest>=3.1.3
 
 # examples
 pandas>=0.20.3


### PR DESCRIPTION
## Affected Issues
- Fixes #34 
- Fixes #121 

## Proposed Changes
- `pip` should be the only Python dependency manager
- `apt` installs are dependent on the distro and Travis whitelist
