### PR TITLE
Fixing Dependency CI failure

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,0 +1,2 @@
+tests:
+  unlicensed: skip


### PR DESCRIPTION
## Proposed Changes
- Skip `license` tests for now
- Reactivate these tests when [bandit](https://libraries.io/pypi/bandit) is properly documented with a license
