### PR TITLE
Disable macOS testing until PyYAML works with Py3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           . venv/bin/activate
           python -V
           pip install -r requirements.txt
-          pip install -r dev-requirements.txt
+          #pip install -r dev-requirements.txt
           python setup.py install
     - run:
         name: test
@@ -44,7 +44,7 @@ jobs:
           python3 -V
           . venv/bin/activate
           python -V
-          python setup.py test
+          #python setup.py test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   linux:
     docker:
-    - image: circleci/python:3.6
+    - image: circleci/python:3
     steps:
     - checkout
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   linux:
     docker:
-    - image: circleci/python:3
+    - image: circleci/python:3.6
     steps:
     - checkout
     - run:


### PR DESCRIPTION
- Homebrew now upgrades to Py3.7
- Wait until https://github.com/yaml/pyyaml/issues/193 is resolved before re-enable macOS testing