### PR TITLE
Abstract Class: Sized moved to abc module

### DIFF
--- a/pybotics/link.py
+++ b/pybotics/link.py
@@ -1,6 +1,6 @@
 """Link module."""
 from abc import abstractmethod
-from collections import Sized
+from collections.abc import Sized
 from typing import Sequence, Union
 
 import attr


### PR DESCRIPTION
Looks like the abstract base class Sized has been moved to the abc module.

## Affected Issues
<!--
Please list issues affected by this PR.
-->
- Fixes #

## Proposed Changes
<!--
Please explain what was changed in this PR.
-->
-
